### PR TITLE
Improve cspell setup and docs wording

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,0 +1,3 @@
+collab
+lezer
+scratchpadview

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ![](assets/scratchpad.png)
 
 > [!NOTE]
-> - This is a temporary note — your content is stored in memory and will be lost when the app is closed unless you manually save it to disk.
+> - This is a temporary note — your content is **not** stored in memory and will be lost when the app is closed, unless you manually save it to disk.
 > - Scratchpad **does not support multiple notes**.
 
 Read the blog at https://bit.ly/4exb8PZ.

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
+
+version: "0.2"
+language: en
+dictionaryDefinitions:
+  - name: project-words
+    path: .cspell/project-words.txt
+dictionaries:
+  - project-words
+ignorePaths:
+  - "**/node_modules/**"
+  - "**/dist/**"


### PR DESCRIPTION
## Summary
- clarify the README note about temporary in-memory content and manual save behavior

  > this was the intended behavior, right?  🤔

- add cspell for repository-wide checks

## Validation
- cspell --no-progress --no-summary "**/*"
- npm run build
